### PR TITLE
Improve validation of user access in Fractalis backend

### DIFF
--- a/fractalis/authorization.py
+++ b/fractalis/authorization.py
@@ -1,0 +1,126 @@
+import functools
+from enum import Enum
+from functools import wraps
+import requests
+import jwt
+from flask import request, jsonify
+import logging
+import json
+
+from jwt.algorithms import RSAAlgorithm
+from werkzeug.exceptions import Unauthorized
+
+logger = logging.getLogger(__name__)
+AuthServiceType = Enum('AuthServiceType', 'OIDC TRANSMART', module=__name__)
+
+
+def authorized(f):
+    @wraps(f)
+    def _wrap(*args, **kwargs):
+        try:
+            payload = request.get_json(force=True)
+            auth = payload.get('auth')
+            token = auth.get('token') if len(auth) != 0 else ''
+            if len(token) == 0:
+                error = "No token in the authentication object."
+                logger.error(error)
+                raise Unauthorized(error)
+            decoded_token = jwt.decode(token, verify=False)
+
+            user = validate_user(decoded_token, auth)
+            identity_provider_url = validate_identity_provider_url(decoded_token, auth)
+            auth_service_type = auth.get('authServiceType', '').upper()
+            if auth_service_type == AuthServiceType.OIDC.name:
+                validate_token(token,  auth.get('oidcClientId'), identity_provider_url)
+            else:
+                logger.warning(f'Token not validated. Validation not supported for "{auth_service_type}" service type')
+        except Exception as e:
+            return jsonify({'error': f'Access unauthorized. {str(e)}'}), 403
+        logger.info(f'Connected: {decoded_token.get("email")!r}, user id (sub): {user!r}')
+        return f(*args, **kwargs)
+    return _wrap
+
+
+def validate_identity_provider_url(decoded_token, auth) -> str:
+    """ Checks if the token issuer (iss) matches the identity provider url from authentication object
+    :param decoded_token: decoded user token
+    :param auth: authentication object from the request arguments
+    :return: identity_provider_url or
+             Unauthorized if urls do not match
+    """
+    token_issuer = f'{decoded_token.get("iss")}/protocol/openid-connect'
+    identity_provider_url = auth.get('oidcServerUrl')
+    if token_issuer != identity_provider_url:
+        error = "Token issuer does not match the identity provider url from authentication object parameter."
+        logger.error(error)
+        raise Unauthorized(error)
+    return identity_provider_url
+
+
+def validate_user(decoded_token, auth):
+    """ Checks if the current user (in the token) matches the user from authentication object
+    :param decoded_token: decoded user token
+    :param auth: authentication object from the request arguments
+    :return: user or
+             Unauthorized if users do not match
+    """
+    subject = decoded_token.get('sub')
+    user = auth.get('user')
+    if user != subject:
+        error = "Token user does not match the user from authentication object parameter."
+        logger.error(error)
+        raise Unauthorized(error)
+    return user
+
+
+def validate_token(token: str, client_id: str, oidc_server_url: str):
+    """ Validate the request token with public key
+    :param token: the user token
+    :param client_id: id of the oidc client
+    :param oidc_server_url: url of the server to authorize with
+    :return: Unauthorized if token is invalid
+    """
+    try:
+        logger.info(f'Validating the token...')
+        decoded_token_header = jwt.get_unverified_header(token)
+        token_kid = decoded_token_header.get('kid')
+        algorithm, public_key = retrieve_keycloak_public_key_and_algorithm(token_kid, oidc_server_url)
+        jwt.decode(token, public_key, algorithms=algorithm, audience=client_id)
+    except Exception as e:
+        error = f"Token validation failed. Reason: {e}."
+        logger.error(error)
+        raise Unauthorized(error)
+
+
+@functools.lru_cache(maxsize=2)
+def retrieve_keycloak_public_key_and_algorithm(token_kid: str, oidc_server_url: str) -> (str, str):
+    """ Retrieve the public key for the token from keycloak
+    :param token_kid: The user token
+    :param oidc_server_url:  Url of the server to authorize with
+    :return: keycloak public key and algorithm
+    """
+    handle = f'{oidc_server_url}/certs'
+    logger.info(f'Getting public key for the kid={token_kid} from the keycloak...')
+    r = requests.get(handle)
+    if r.status_code != 200:
+        error = "Could not get certificates from the keycloak. " \
+                "Reason: [{}]: {}".format(r.status_code, r.text)
+        logger.error(error)
+        raise ValueError(error)
+    try:
+        json_response = r.json()
+    except Exception:
+        error = "Could not retrieve the public key. " \
+                 "Got unexpected response: '{}'".format(r.text)
+        logger.error(error)
+        raise ValueError(error)
+    try:
+        matching_key = next((item for item in json_response.get('keys') if item['kid'] == token_kid), None)
+        matching_key_json = json.dumps(matching_key)
+        public_key = RSAAlgorithm.from_jwk(matching_key_json)
+    except Exception as e:
+        error = f'Invalid public key!. Reason: {e}'
+        logger.error(error)
+        raise ValueError(error)
+    logger.info(f'The public key for the kid={token_kid} has been fetched.')
+    return matching_key.get('alg'), public_key

--- a/fractalis/data/etlhandler.py
+++ b/fractalis/data/etlhandler.py
@@ -7,6 +7,8 @@ import logging
 from uuid import uuid4
 from typing import List, Union
 
+from werkzeug.exceptions import Unauthorized
+
 from fractalis.cleanup import janitor
 from fractalis import app, redis, celery
 from fractalis.data.etl import ETL
@@ -52,7 +54,7 @@ class ETLHandler(metaclass=abc.ABCMeta):
         self._server = server
         # if no token is given we have to get one
         try:
-            self._token = auth['token']
+            self._token = auth.get('token')
             if not isinstance(self._token, str) or len(self._token) == 0:
                 raise KeyError
         except KeyError:
@@ -62,7 +64,7 @@ class ETLHandler(metaclass=abc.ABCMeta):
                 self._token = self._get_token_for_credentials(server, auth)
             except Exception as e:
                 logger.exception(e)
-                raise ValueError("Could not authenticate with API.")
+                raise ValueError(f"Could not authenticate with API. {e}")
 
     @staticmethod
     @abc.abstractmethod

--- a/fractalis/data/etls/transmart/handler_transmart.py
+++ b/fractalis/data/etls/transmart/handler_transmart.py
@@ -2,13 +2,15 @@
 tranSMART."""
 
 import logging
-
+from enum import Enum
 import requests
 
 from fractalis.data.etlhandler import ETLHandler
 
 
 logger = logging.getLogger(__name__)
+
+AuthServiceType = Enum('AuthServiceType', 'OIDC TRANSMART', module=__name__)
 
 
 class TransmartHandler(ETLHandler):
@@ -28,24 +30,11 @@ class TransmartHandler(ETLHandler):
     def make_label(descriptor: dict) -> str:
         return descriptor['label']
 
-    def _get_token_for_credentials(self, server: str, auth: dict) -> str:
-        try:
-            user = self.get_auth_value(auth, 'user')
-            passwd = self.get_auth_value(auth, 'passwd')
-            auth_service_type = self.get_auth_value(auth, 'authServiceType')
-            if auth_service_type.upper() == 'OIDC':
-                client_id = self.get_auth_value(auth, 'oidcClientId')
-                url = self.get_auth_value(auth, 'oidcServerUrl')
-            elif auth_service_type.upper() == 'TRANSMART':
-                client_id = 'glowingbear-js'
-                url = server + '/oauth/token'
-            else:
-                raise KeyError("The authentication service type in authentication object has to be one of "
-                               "'oidc', 'transmart'")
-        except KeyError as e:
-            logger.error(e)
-            raise ValueError(e)
-
+    @staticmethod
+    def retrieve_token(url: str, client_id: str, user: str, passwd: str) -> str:
+        """
+        Retrieve access token from the server.
+        """
         r = requests.post(url=url,
                           params={
                               'grant_type': 'password',
@@ -63,16 +52,39 @@ class TransmartHandler(ETLHandler):
             raise ValueError(error)
         try:
             response = r.json()
-            return response['access_token']
         except Exception:
             error = "Could not authenticate. " \
                     "Got unexpected response: '{}'".format(r.text)
             logger.error(error)
             raise ValueError(error)
+        return response['access_token']
 
     @staticmethod
     def get_auth_value(auth: dict, property_name: str) -> str:
-        value = auth[property_name]
+        value = auth.get(property_name, '')
         if len(value) == 0:
             raise KeyError(f'The authentication object must contain the non-empty field: "{property_name}"')
         return value
+
+    def get_client_id_and_url(self, server: str, auth: dict, ) -> (str, str):
+        auth_service_type = self.get_auth_value(auth, 'authServiceType').upper()
+        if auth_service_type == AuthServiceType.OIDC.name:
+            client_id = self.get_auth_value(auth, 'oidcClientId')
+            url = self.get_auth_value(auth, 'oidcServerUrl')
+        elif auth_service_type == AuthServiceType.TRANSMART.name:
+            client_id = 'glowingbear-js'
+            url = server + '/oauth/token'
+        else:
+            raise KeyError("The authentication service type in authentication object has to be one of "
+                           "'oidc', 'transmart'")
+        return client_id, url
+
+    def _get_token_for_credentials(self, server: str, auth: dict) -> str:
+        try:
+            user = self.get_auth_value(auth, 'user')
+            passwd = self.get_auth_value(auth, 'passwd')
+            client_id, url = self.get_client_id_and_url(server, auth)
+        except KeyError as e:
+            logger.error(e)
+            raise ValueError(e)
+        return self.retrieve_token(url, client_id, user, passwd)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'pytest-runner',
         'pytest-cov',
         'responses',
-        'twine'
+        'twine',
+        'pyjwt==1.6.3'
     ]
 )

--- a/tests/unit/etls/transmart/test_handler_transmart.py
+++ b/tests/unit/etls/transmart/test_handler_transmart.py
@@ -48,8 +48,8 @@ class TestTransmartHandler:
         with pytest.raises(ValueError) as e:
             TransmartHandler(server='http://foo.bar',
                              auth={'user': 'foo', 'passwd': 'bar', 'authServiceType': 'test_server_name'})
-            assert 'The authentication service type in authentication object has to be one of ' \
-                   '"oidc", "transmart"' in e
+        assert 'Could not authenticate with API. "The authentication service type in authentication object has to be ' \
+               'one of \'oidc\', \'transmart\'"' in str(e.value)
 
     def test_returns_token_for_credentials(self):
         with responses.RequestsMock() as response:
@@ -82,7 +82,7 @@ class TestTransmartHandler:
             with pytest.raises(ValueError) as e:
                 TransmartHandler(server='http://foo.bar',
                                  auth={'user': 'foo', 'passwd': 'bar', 'authServiceType': 'transmart'})
-                assert 'unexpected response' in e
+            assert 'unexpected response' in str(e.value)
 
     def test_auth_raises_exception_for_non_200_return(self):
         with responses.RequestsMock() as response:
@@ -93,4 +93,5 @@ class TestTransmartHandler:
             with pytest.raises(ValueError) as e:
                 TransmartHandler(server='http://foo.bar',
                                  auth={'user': 'foo', 'passwd': 'bar', 'authServiceType': 'transmart'})
-                assert '[400]' in e
+            assert '[400]' in str(e.value)
+


### PR DESCRIPTION
Summary of the proposal:
1. Add support for keycloak authorization;
2. Add token validation with keycloak (includes fetching and caching a public key from keycloak);

This includes extending parameters that would be required for `auth` object:
- `authServiceType` - Authentication service type (`oidc`, `transmart`)

when specifying `oidc` service type, these parameters are also required:
- `oidcClientId` - keycloak client id
- `oidcServerUrl` - keycloak server url

Token will be validated only, when `authServiceType = 'oidc'`.

_Update_:
As mentioned in the [comments to the original PR](https://github.com/thehyve/Fractalis/pull/1), there are some changes that should still be considered: 
- move `authServiceType` property to the `app.config` instead of `auth` object that is passed in the request
- changes to the session (storing user id) 